### PR TITLE
Fix: TDCardDelegate.getSwipebleCard

### DIFF
--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -385,7 +385,7 @@
         $rootScope.$emit('tdCard.pop', isAnimated);
       },
       getSwipebleCard: function($scope) {
-        return $scope.$parent.swipeCard;
+        return $scope.swipeCard;
       }
     }
   }]);


### PR DESCRIPTION
Another pull request addresses the misspelling.  This commit fixes the function itself.