### PR TITLE
Fix issue associated with other pages unable to scroll

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -12,13 +12,13 @@ angular.module('starter', ['ionic', 'ionic.contrib.ui.tinderCards'])
 
 })
 
-.directive('noScroll', function($document) {
+.directive('noScroll', function() {
 
   return {
     restrict: 'A',
     link: function($scope, $element, $attr) {
 
-      $document.on('touchmove', function(e) {
+      $element.on('touchmove', function(e) {
         e.preventDefault();
       });
     }


### PR DESCRIPTION
After loading a page with an element having the no-scroll directive, other pages were not able to scroll when navigating to them.