### PR TITLE
Feature: Added snapBack function on SwipeableCardView

### DIFF
--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -116,6 +116,13 @@
     swipe: function() {
       this.transitionOut();
     },
+    
+    /**
+     * Snap the card back to its original position
+     */
+    snapBack: function() {
+      this.onSnapBack(this.x, this.y, this.rotationAngle);
+    },
 
     isUnderThreshold: function() {
       //return true;

--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -319,6 +319,11 @@
                 leftText.style.opacity = Math.max(leftText.style.opacity - leftText.style.opacity * v, 0);
               })
               .start();
+
+              $timeout(function() {
+                $scope.onSnapBack();
+              });
+
               /*
               animateSpringViaCss(el, 0, 0.5, 50, 700, 10, function (x) {
                 return el.style.transform = el.style.webkitTransform = 'translate3d(' + x + 'px,0,0)';


### PR DESCRIPTION
This can be useful in case you want some conditional logic in your
cardDestroyed event handler to decide whether to remove the card from
the collection or snap it back.  For example if the “like” failed or
user was not logged in, etc.