### PR TITLE
Fix name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ionic-contrib-tinder-cards",
+  "name": "ionic-ion-tinder-cards",
   "version": "1.0.0",
   "codename": "lanthanum-leopard",
   "homepage": "https://github.com/driftyco/ionic-contrib-tinder-cards",


### PR DESCRIPTION
Bower install is broken due to the incorrect name