### PR TITLE
Fix for when there are more or less than 3 cards

### DIFF
--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -366,14 +366,13 @@
         };
 
         this.partial = function(amt) {
-          cards = $element[0].querySelectorAll('td-card');
-          firstCard = cards[0];
-          secondCard = cards[1];
-          thirdCard = cards[2];
-          if(!secondCard) { return; }
+          var i = 0, length = 0;
 
-          bringCardUp(secondCard, amt, 4);
-          bringCardUp(thirdCard, amt, 8);
+          cards = $element[0].querySelectorAll('td-card');
+          length = cards.length;
+          for (i = 1; i < length; i += 1) {
+            bringCardUp(cards[i], amt, 4 * i);
+          }
         };
       }
     }


### PR DESCRIPTION
When there are 2 cards it throws errors because it never checks if thirdCard is undefined. This change fixes that and allows the cases when you have more than 3 cards.