### PR TITLE
Fixed flickering: don't call bringCardUp on the top card

### DIFF
--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -431,8 +431,8 @@
         this.partial = function(amt) {
           cards = $element[0].querySelectorAll('td-card');
           firstCard = cards[0];
-          secondCard = cards[1];
-          thirdCard = cards[2];
+          secondCard = cards.length > 2 && cards[1];
+          thirdCard = cards.length > 3 && cards[2];
 
           secondCard && bringCardUp(secondCard, amt, 4);
           thirdCard && bringCardUp(thirdCard, amt, 8);


### PR DESCRIPTION
My fix for https://github.com/driftyco/ionic-ion-tinder-cards/issues/11