### PR TITLE
Add 'include collide.js' to usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: There is also a similar ion library here: https://github.com/driftyco/ioni
 
 ## Usage
 
-Include `ionic.tdcards.js` and `ionic.tdcards.css` after the rest of your Ionic and Angular includes. Add `ionic.contrib.ui.tinderCards` as a module dependency of your app. Then use the following AngularJS directives:
+Include `ionic.tdcards.js`, `collide.js` and `ionic.tdcards.css` after the rest of your Ionic and Angular includes. Add `ionic.contrib.ui.tinderCards` as a module dependency of your app. Then use the following AngularJS directives:
 
 ```html
 <td-cards>


### PR DESCRIPTION
For the swipe to work properly, we need collide.js. Currently, README.md only says to include 'ionic.tdcards.js' and 'ionic.tdcards.css'. This could easily cause new users to run into errors, which would be avoidable by adding 'collide.js' to the list of things to include under the Usage section in the Readme.