### PR TITLE
Add ability to limit the number of visible cards.

### DIFF
--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -395,7 +395,9 @@
       restrict: 'E',
       template: '<div class="td-cards" ng-transclude></div>',
       transclude: true,
-      scope: {},
+      scope: {
+        maxStackSize: '=' // Max visible number of cards
+      },
       controller: ['$scope', '$element', function($scope, $element) {
         var cards;
         var firstCard, secondCard, thirdCard;
@@ -411,7 +413,8 @@
             card = existingCards[i];
             if(!card) continue;
             if(i > 0) {
-              card.style.transform = card.style.webkitTransform = 'translate3d(0, ' + (i * 4) + 'px, 0)';
+              var cardOffsetIndex = ($scope.maxStackSize && ($scope.maxStackSize - 1) < i) ? $scope.maxStackSize - 1 : i;
+              card.style.transform = card.style.webkitTransform = 'translate3d(0, ' + (cardOffsetIndex * 4) + 'px, 0)';
             }
             card.style.zIndex = (existingCards.length - i);
           }

--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -365,8 +365,10 @@
               }) 
 
               .on('step', function(v) {
+                var xPos = startX - startX*v;
+                swipeCards.partial(xPos / (swipeableCard.parentWidth / 2));
                 //Have the element spring over 400px
-                el.style.transform = el.style.webkitTransform = 'translate3d(' + (startX - startX*v) + 'px, ' + (startY - startY*v) + 'px, 0) rotate(' + (startRotation - startRotation*v) + 'rad)';
+                el.style.transform = el.style.webkitTransform = 'translate3d(' + xPos + 'px, ' + (startY - startY*v) + 'px, 0) rotate(' + (startRotation - startRotation*v) + 'rad)';
                 if (rightText) rightText.style.opacity = 0;
                 if (leftText) leftText.style.opacity = 0;
               })

--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -396,9 +396,12 @@
       template: '<div class="td-cards" ng-transclude></div>',
       transclude: true,
       scope: {
-        maxStackSize: '=' // Max visible number of cards
+        maxStackSize: '=', // Max visible number of cards
+        cardPixelOffset: '=' // Offset of each card
       },
       controller: ['$scope', '$element', function($scope, $element) {
+        var PIXEL_OFFSET = $scope.cardPixelOffset || 4;
+
         var cards;
         var firstCard, secondCard, thirdCard;
 
@@ -414,7 +417,7 @@
             if(!card) continue;
             if(i > 0) {
               var cardOffsetIndex = ($scope.maxStackSize && ($scope.maxStackSize - 1) < i) ? $scope.maxStackSize - 1 : i;
-              card.style.transform = card.style.webkitTransform = 'translate3d(0, ' + (cardOffsetIndex * 4) + 'px, 0)';
+              card.style.transform = card.style.webkitTransform = 'translate3d(0, ' + (cardOffsetIndex * PIXEL_OFFSET) + 'px, 0)';
             }
             card.style.zIndex = (existingCards.length - i);
           }
@@ -427,7 +430,7 @@
         var bringCardUp = function(card, amt, max) {
           var position, newTop;
           position = card.style.transform || card.style.webkitTransform;
-          newTop = Math.max(0, Math.min(max, max - (max * Math.abs(amt))));
+          newTop = Math.max(0, Math.max(max - PIXEL_OFFSET, max - (PIXEL_OFFSET * Math.abs(amt))));
           card.style.transform = card.style.webkitTransform = 'translate3d(0, ' + newTop + 'px, 0)';
         };
 
@@ -437,8 +440,8 @@
           secondCard = cards.length > 2 && cards[1];
           thirdCard = cards.length > 3 && cards[2];
 
-          secondCard && bringCardUp(secondCard, amt, 4);
-          thirdCard && bringCardUp(thirdCard, amt, 8);
+          secondCard && bringCardUp(secondCard, amt, PIXEL_OFFSET);
+          thirdCard && bringCardUp(thirdCard, amt, PIXEL_OFFSET * 2);
         };
       }]
     }

--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -211,7 +211,12 @@
       this.rotationDirection = -1;
     },
 
+    isDragDisabled: function() { // Can be overriden
+      return false;
+    },
+
     _doDragStart: function(e) {
+      if (this.isDragDisabled()) return;
       e.preventDefault();
       var width = this.el.offsetWidth;
       var point = window.innerWidth / 2 + this.rotationDirection * (width / 2)
@@ -221,6 +226,7 @@
     },
 
     _doDrag: function(e) {
+      if (this.isDragDisabled()) return;
       e.preventDefault();
 
       var o = e.gesture.deltaX / -1000;
@@ -241,6 +247,7 @@
       });
     },
     _doDragEnd: function(e) {
+      if (this.isDragDisabled()) return;
       this.transitionOut(e);
     }
   });
@@ -279,7 +286,8 @@
         onTransitionOut: '&',
         onPartialSwipe: '&',
         onSnapBack: '&',
-        onDestroy: '&'
+        onDestroy: '&',
+        dragDisabled: '&'
       },
       compile: function(element, attr) {
         return function($scope, $element, $attr, swipeCards) {
@@ -295,6 +303,9 @@
             el: el,
             leftText: leftText,
             rightText: rightText,
+            isDragDisabled: function() {
+              return $scope.dragDisabled();
+            },
             onPartialSwipe: function(amt) {
               swipeCards.partial(amt);
               var self = this;

--- a/ionic.tdcards.js
+++ b/ionic.tdcards.js
@@ -439,8 +439,8 @@
         this.partial = function(amt) {
           cards = $element[0].querySelectorAll('td-card');
           firstCard = cards[0];
-          secondCard = cards.length > 2 && cards[1];
-          thirdCard = cards.length > 3 && cards[2];
+          secondCard = cards.length >= 2 && cards[1];
+          thirdCard = cards.length >= 3 && cards[2];
 
           secondCard && bringCardUp(secondCard, amt, PIXEL_OFFSET);
           thirdCard && bringCardUp(thirdCard, amt, PIXEL_OFFSET * 2);


### PR DESCRIPTION
Hi,

Right now your version displays all cards available in the source array with 4px vertical offset. On the other hand Tinder displays only 3 cards.

I have added attribute called "max-stack-size" to configure this value. For example, if you put value 3 in it and if your array has more than 3 elements, then all cards starting from index 3 will be initially hidden behind the card with index 2.

Regards,
Vladimir